### PR TITLE
Remove a PHP warning

### DIFF
--- a/plugins/content/jcomments.php
+++ b/plugins/content/jcomments.php
@@ -24,7 +24,7 @@ jimport('joomla.plugin.plugin');
  */
 class plgContentJComments extends JPlugin
 {
-	function plgContentJComments(&$subject, $config)
+	function __construct(&$subject, $config)
 	{
 		parent::__construct($subject, $config);
 	}


### PR DESCRIPTION
Deprecated: Methods with the same name as their class will not be constructors in a future version of PHP;